### PR TITLE
Image Containment and content padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,7 +1496,7 @@
             "jest-worker": "^25.1.0",
             "p-limit": "^2.2.2",
             "schema-utils": "^2.6.4",
-            "serialize-javascript": ">=3.1.0",
+            "serialize-javascript": "^2.1.2",
             "source-map": "^0.6.1",
             "terser": "^4.4.3",
             "webpack-sources": "^1.4.3"
@@ -2465,7 +2465,7 @@
         "browserify-rsa": "^4.0.0",
         "create-hash": "^1.1.0",
         "create-hmac": "^1.1.2",
-        "elliptic": ">=6.5.3",
+        "elliptic": "^6.0.0",
         "inherits": "^2.0.1",
         "parse-asn1": "^5.0.0"
       }
@@ -3249,7 +3249,7 @@
         "normalize-path": "^3.0.0",
         "p-limit": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": ">=3.1.0",
+        "serialize-javascript": "^2.1.2",
         "webpack-log": "^2.0.0"
       },
       "dependencies": {
@@ -10496,7 +10496,7 @@
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": ">=3.1.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/src/components/NewsArticleCard.vue
+++ b/src/components/NewsArticleCard.vue
@@ -1,29 +1,55 @@
 <template>
-    <div class="ui card article content">
-        <a class="image card-image" :href="url" target="_blank" rel="noopener noreferrer">
-            <img :src="urlToImage" alt="news article thumbnail">
-        </a>
-        
-        <p><a :href="url" target="blank" class="header">{{title}}</a></p>
-        <div class="description">
-            {{description}}
-        </div>
+  <div class="ui card article content">
+    <a
+      class="image card-image"
+      :href="url"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img :src="urlToImage" alt="news article thumbnail" />
+    </a>
+
+    <div class="content-text">
+      <p>
+        <a :href="url" target="blank" class="header">{{ title }}</a>
+      </p>
+      <div class="description">
+        {{ description }}
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
 export default {
-    name: 'NewsArticleCard',
-    props: ['title', 'description', 'url', 'urlToImage', 'publishedAt', 'sourceName']
-}
+  name: 'NewsArticleCard',
+  props: [
+    'title',
+    'description',
+    'url',
+    'urlToImage',
+    'publishedAt',
+    'sourceName',
+  ],
+};
 </script>
 
 <style>
 .card-image {
-    margin-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 
-.article .description, .header{
-    font-size: 1.25rem;
+.card-image img {
+  object-fit: cover;
+  height: 12rem !important;
+}
+
+.article .description,
+.header {
+  font-size: 1.25rem;
+}
+
+.content-text {
+  margin: 0 0.5rem 1rem 0.5rem;
 }
 </style>


### PR DESCRIPTION
- **Content Padding**
_Added a div with padding around the text content for each news item to stop the text from colliding with the side and also making it look a bit neater._
- **Image Containment**
_Added an 'object-fit' property to the image for each news article. Now instead of each image being different sizes all they all now line up and look neater._

---

### Original news article view
<img width="613" alt="image" src="https://user-images.githubusercontent.com/271838/97295875-cada9780-1847-11eb-9efb-f674a18a486a.png">

### Updated news article view
<img width="613" alt="image" src="https://user-images.githubusercontent.com/271838/97295913-d6c65980-1847-11eb-9efa-27a7edae5e54.png">
